### PR TITLE
Add default opts for toggleterm to config

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,7 +26,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Lint with stylua
-      uses: JohnnyMorganz/stylua-action@1.0.0
+      uses: JohnnyMorganz/stylua-action@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
         args: --check .

--- a/README.md
+++ b/README.md
@@ -98,8 +98,8 @@ require('toggletasks').setup {
     lsp_priorities = {
         ['null-ls'] = -10,
     },
-    -- Default values for task configuration options (available options described later)
-    defaults = {
+    -- Defaults used when opening task's terminal (see Terminal:new() in toggleterm/terminal.lua)
+    toggleterm = {
         close_on_exit = false,
         hidden = true,
     },

--- a/lua/toggletasks/config.lua
+++ b/lua/toggletasks/config.lua
@@ -27,7 +27,7 @@ local function defaults()
         lsp_priorities = {
             ['null-ls'] = -10,
         },
-        defaults = {
+        toggleterm = {
             close_on_exit = false,
             hidden = true,
         },

--- a/lua/toggletasks/utils.lua
+++ b/lua/toggletasks/utils.lua
@@ -32,6 +32,14 @@ M.warn_once = logger(vim.log.levels.WARN, 'notify_once')
 M.error = logger(vim.log.levels.ERROR, 'notify')
 M.error_once = logger(vim.log.levels.ERROR, 'notify_once')
 
+function M.deprecated(old_name, old_value, new_name, new_value)
+    if old_value then
+        M.warn_once('toggletasks.nvim: %s is deprecated, use %s', old_name, new_name)
+    end
+    -- New value overrides the old one
+    return new_value or old_value
+end
+
 function M.as_table(v)
     return type(v) ~= 'table' and { v } or v
 end


### PR DESCRIPTION
Closes https://github.com/jedrzejboczar/toggletasks.nvim/issues/8

Default options for toggleterm terminals spawned by toggletasks can now be specified in setup, e.g.
```lua
require('toggletasks').setup {
    toggleterm = {
        on_open = function(term) print('on open') end,
    },
}
```
As for now all options supported by toggleterm can be used, besides `cmd`, `dir` and `env`.

Note that `defaults` has been renamed to `toggleterm` and a deprecation message will show up.